### PR TITLE
fix widget panel redirecting to homepage issue

### DIFF
--- a/templates/app/widget-panel-option.html
+++ b/templates/app/widget-panel-option.html
@@ -1,5 +1,5 @@
 <li>
-    <a href="#" style="padding: 0 0 0 0;" >
+    <a style="padding: 0 0 0 0;" >
         <label id="<%= widget.get('widgetName') %>-option" style="border-width: 0 0 0 0; margin: 0 0 0 0;" data-corners="false" >
             <input type="checkbox" />
             <h3><%= widget.get('title') %></h3>


### PR DESCRIPTION
Hi! The issue was that checking a widget to select it causes redirecting to homepage. The issue was caused by 
`href="#"` inside a link element. I'm not sure why it only starts to cause issue after FastClick was used. But I think it's fixed now. I tested it on my Android (v4.4) 's Chrome browser, and Firefox and Chrome on my Mac. 
