### PR TITLE
seems to fixes panel closing issue with fastclick #2761

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -63,6 +63,9 @@ require([ "jquery", "backbone", "routers/mobileRouter", "fetchcache", "app", "fa
         $.mobile.defaultPageTransition = "slide";
 
         FastClick.attach(document.body);
+
+        // avoid fastclick interfering with panel closing
+        $("div[data-role='panel']").attr('data-classes', '{"modal":"needsclick ui-panel-dismiss"}');
     } );
 
     require( [ "jquerymobile" ], function() {


### PR DESCRIPTION
Adding needsclick to the panel seems to fix the panel not closing issue.
- works on Nexus 4
- with Chrome emulator, tested for iPhone 4 and 5, seems to work
  (I noticed that with Chrome emulation of iPhone, I had to **re-type in** the mobile url for it to work, simply refreshing the existing page seems to make everything non-responsive)
