### PR TITLE
fix header and removeSwipe

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <div data-role="page" id="home-page" class="ui-page ui-body-c ui-page-header-fixed ui-page-panel ui-page-active">
       <div data-role="panel" id="menu-panel" class="ui-panel ui-panel-position-left ui-panel-display-reveal ui-panel-closed ui-body-c ui-panel-animate"></div>
 
-      <div data-role="header" data-position="" data-tap-toggle="false" class="ui-header ui-bar-a ui-header-fixed slidedown ui-panel-content-fixed-toolbar ui-panel-animate ui-panel-content-fixed-toolbar-closed">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false" class="ui-header ui-bar-a ui-header-fixed slidedown ui-panel-content-fixed-toolbar ui-panel-animate ui-panel-content-fixed-toolbar-closed">
         <a href="#menu-panel" data-icon="bars" data-iconpos="notext" class="ui-btn-left ui-btn ui-btn-up-a ui-shadow ui-btn-corner-all ui-btn-icon-notext"><span class="ui-btn-inner"><span class="ui-btn-text">Menu</span><span class="ui-icon ui-icon-bars ui-icon-shadow">&nbsp;</span></span></a>
         <h1 class="ui-title">WormBase</h1>
         <a href="#search" data-transition="slidefade" data-icon="search" data-iconpos="notext" class="ui-btn-right ui-btn ui-shadow ui-btn-corner-all ui-btn-icon-notext ui-btn-up-a"><span class="ui-btn-inner"><span class="ui-btn-text">
@@ -44,7 +44,7 @@
     <!-- START history-page -->
     <div data-role="page" id="history-page" data-url="history-page">
       <div data-role="panel" id="menu-panel"></div>
-      <div data-role="header" data-position="" data-tap-toggle="false">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false">
         <a href="#menu-panel" data-icon="bars" data-iconpos="notext">Menu</a>
         <h1>WormBase</h1>
         <a href="#search" data-transition="slidefade" data-icon="search" data-iconpos="notext">
@@ -62,7 +62,7 @@
     <!-- START search-page -->
     <div data-role="page" id="search-page" data-url="search-page">
       <div data-role="panel" id="menu-panel"></div>    
-      <div data-role="header" data-position="" data-tap-toggle="false">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false">
         <a href="#menu-panel" class="ui-btn-left" data-role="button" data-icon="bars" data-mini="true" data-iconpos="notext">Menu</a>
         <div style="margin-left:40px">
           <input type="search" name="search" data-mini="true" value="">
@@ -90,7 +90,7 @@
           <!-- list of widgets goes here -->
         </ul>
       </div>
-      <div data-role="header" data-position="" data-tap-toggle="false">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false">
         <a href="#menu-panel" data-icon="bars" data-iconpos="notext" id="openAppMenuButton" onClick="something2()">Menu</a>
         <h1 class="ui-title">WormBase</h1>
         <a href="#widgets-panel" id="openWidgetsPanelButton" data-icon="grid" data-iconpos="false" onClick="something()">Widgets</a>
@@ -116,7 +116,7 @@
     <!-- START browsing-page -->
     <div data-role="page" id="browsing-page" data-url="browsing-page">
       <div data-role="panel" id="menu-panel"></div>
-      <div data-role="header" data-position="" data-tap-toggle="false">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false">
         <a href="#menu-panel" data-icon="bars" data-iconpos="notext">Menu</a>
         <h1>WormBase</h1>
         <a href="#search" data-transition="slidefade" data-icon="search" data-iconpos="notext">
@@ -133,7 +133,7 @@
     <!-- START filter-page -->
     <div data-role="page" id="filter-page" data-url="filter-page">
       <div data-role="panel" id="menu-panel"></div>
-      <div data-role="header" data-position="" data-tap-toggle="false">
+      <div data-role="header" data-position="fixed" data-tap-toggle="false">
         <a href="#menu-panel" class="ui-btn-left" data-role="button" data-icon="bars" data-mini="true" data-iconpos="notext">Menu</a>
         <div style="margin-left:40px">
           <input type="search" name="search" data-mini="true" value="" id="filter-search">

--- a/js/views/AppView.js
+++ b/js/views/AppView.js
@@ -50,17 +50,6 @@ define([ "jquery",
                     },
                 };
 
-                // Menu panel swipe to open
-                this.$el.on('swiperight', function(event) {
-                    if($.mobile.activePage.find('#widgets-panel').hasClass('ui-panel-closed')){
-                        $(event.target).parents('div[data-role=page]').find('#menu-panel').panel('open');
-                    }
-                } );
-                this.$el.on('swipeleft', function() { 
-                    if($.mobile.activePage.find('#widgets-panel').hasClass('ui-panel-closed')){
-                        $(event.target).parents('div[data-role=page]').find('#menu-panel').panel('close');
-                    }
-                } );
             },
 
             home: function() {

--- a/js/views/ObjectView.js
+++ b/js/views/ObjectView.js
@@ -31,17 +31,6 @@ define([ "jquery",
                 this.model.widgets.on("reset", this.reset, this);
 
                 this.model.on("change:id", this.changeObject, this);
-
-                this.$el.on('swipeleft', function() { 
-                    if($.mobile.activePage.find('#menu-panel').hasClass('ui-panel-closed')){
-                        self.panelView.$el.panel('open');
-                    }
-                } );
-                this.$el.on('swiperight', function() {
-                    if($.mobile.activePage.find('#menu-panel').hasClass('ui-panel-closed')){
-                        self.panelView.$el.panel('close');
-                    }
-                } );
                 
             },
 


### PR DESCRIPTION
WormBase/website#2901 
- Makes header fixed, so menu and widget buttons are always accessible
- remove listeners on menu and widget panel for swipe actions (which interfered with scrolling)

I accidentally pushed Fastclick update to mobile-site-release branch
